### PR TITLE
refactor: update import statements to use node: prefix and improve logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,13 @@ FROM node:20-slim AS runner
 ENV NODE_ENV=production TZ=UTC
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates fonts-liberation wget \
-      python3 \
+      ca-certificates fonts-liberation \
       libgbm1 libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
       libexpat1 libfontconfig1 libgcc1 libgdk-pixbuf2.0-0 libglib2.0-0 \
       libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 \
       libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 \
       libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-      xdg-utils && \
+      xdg-utils wget && \
     rm -rf /var/lib/apt/lists/*
     
 WORKDIR /usr/src/app

--- a/routes/index.route.js
+++ b/routes/index.route.js
@@ -6,7 +6,7 @@ import {
   healthCheckController,
 } from '../controllers/message.controller.js';
 
-export default function (app, client) {
+const registerRoutes = (app, client) => {
   app.get('/', healthCheckController);
 
   app.post('/send-message', verifyKey, conditionalUpload, (req, res) =>
@@ -16,4 +16,6 @@ export default function (app, client) {
   app.get('/get-group-id', verifyKey, (req, res) =>
     getGroupIdController(req, res, client),
   );
-}
+};
+
+export default registerRoutes;

--- a/services/message.service.js
+++ b/services/message.service.js
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync } from 'fs';
-import { basename } from 'path';
+import { readFileSync, existsSync } from 'node:fs';
+import { basename } from 'node:path';
 import whatsappWeb from 'whatsapp-web.js';
 import { logWithDate } from '../utils/logger.js';
 import { getMimeType, isWhatsAppSupported } from '../utils/mimeTypes.js';
@@ -90,9 +90,10 @@ function createMedia(filename, base64Data, fallbackMimeType = null) {
     throw new Error(`Unsupported file type: ${filename}`);
   }
 
-  const mimetype = fallbackMimeType === null
-    ? getMimeType(filename)
-    : getMimeType(filename, fallbackMimeType);
+  const mimetype =
+    fallbackMimeType === null
+      ? getMimeType(filename)
+      : getMimeType(filename, fallbackMimeType);
   return new MessageMedia(mimetype, base64Data, filename);
 }
 

--- a/utils/commands.js
+++ b/utils/commands.js
@@ -1,12 +1,12 @@
-import { readFileSync, watch } from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { readFileSync, watch } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { logWithDate } from './logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-let COMMANDS = {};
+const COMMANDS = {};
 let isWatching = false;
 let watcher = null;
 

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,4 +1,4 @@
-import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 
 export function logWithDate(message) {
   let date = new Date().toLocaleString('en-US', { timeZone: 'Asia/Jakarta' });

--- a/utils/mimeTypes.js
+++ b/utils/mimeTypes.js
@@ -1,4 +1,4 @@
-import { extname } from 'path';
+import { extname } from 'node:path';
 
 export const MIME_TYPES = {
   jpg: 'image/jpeg',


### PR DESCRIPTION
- Changed import paths in multiple files to use the 'node:' prefix for core modules.
- Enhanced error logging in command handling to provide better debugging information.